### PR TITLE
Add AndroidSVG dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)
+    implementation(libs.androidsvg.aar)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.0-rc01"
+agp = "8.7.3"
 androidsvgAar = "1.4"
 kotlin = "1.9.24"
 coreKtx = "1.15.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.7.0-rc01"
+androidsvgAar = "1.4"
 kotlin = "1.9.24"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -26,6 +27,7 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
+androidsvg-aar = { module = "com.caverock:androidsvg-aar", version.ref = "androidsvgAar" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This pull request includes updates to the project's dependencies to add support for the AndroidSVG library and to update the Android Gradle Plugin (AGP) version.

Dependency updates:

* [`app/build.gradle.kts`](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R49): Added `implementation(libs.androidsvg.aar)` to include the AndroidSVG library.
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL2-R3): Updated the AGP version from `8.7.0-rc01` to `8.7.3` and added a new version entry for `androidsvgAar`.

Library addition:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR30): Added a new entry for `androidsvg-aar` under the libraries section to reference the AndroidSVG library.